### PR TITLE
Add feature: image comparison with slider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "image-compressroar",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@cloudfour/image-compare": "^1.0.5"
+      },
       "devDependencies": {
         "@11ty/eleventy": "3.0.0-alpha.14",
         "browserslist": "^4.23.1",
@@ -198,6 +201,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@cloudfour/image-compare": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@cloudfour/image-compare/-/image-compare-1.0.5.tgz",
+      "integrity": "sha512-2rYQphoQ6eqIjxmBfaWAAkuHFZ5ziT/vCcaijh0SAtCTPOMyP5guklHsQpMQymTBWsQ4FtT5tPqNDVC+orI4kQ==",
+      "license": "ISC"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.23.0",

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
     "last 2 versions",
     "not dead",
     "> 0.2%"
-  ]
+  ],
+  "dependencies": {
+    "@cloudfour/image-compare": "^1.0.5"
+  }
 }

--- a/src/css/_base.css
+++ b/src/css/_base.css
@@ -1,1 +1,5 @@
 @import "_reset.css";
+
+a:not([href]) {
+  display: none;
+}

--- a/src/css/_components.css
+++ b/src/css/_components.css
@@ -1,6 +1,7 @@
 @import "_imgInput.css";
 @import "_button.css";
 @import "_slider.css";
+@import "_image-compare.css";
 
 .container {
     margin: auto;
@@ -11,10 +12,6 @@
 
 #errorMSG, #downloadLink {
     font-size: 1.5rem;
-}
-
-#imgPreview {
-    display: none;
 }
 
 @media only screen and (max-width: 600px){

--- a/src/css/_image-compare.css
+++ b/src/css/_image-compare.css
@@ -1,0 +1,4 @@
+image-compare {
+  margin-inline: auto;
+  width: var(--image-compare-width);
+}

--- a/src/index.html
+++ b/src/index.html
@@ -28,10 +28,15 @@
     <button id="compressBtn" onclick="compressImage()">Compress</button><!--Compress button-->
 
     <br />
-    <a id="downloadLink" download="compressed_image.jpg" style="display: none">Download Compressed Image</a>
+    <a id="downloadLink" download="compressed_image.jpg">Download Compressed Image</a>
     <p id="errorMSG"></p> <!-- Error message -->
     <canvas id="canvas" width="320" height="256" style="display: none;"></canvas>
   </div>
-  <img id="imgPreview" src="" alt="Result preview" style="margin: auto;"><br/>
+
+  <!-- Image Compare Component -->
+   <image-compare>
+    <img slot="image-1" alt="">
+    <img slot="image-2" alt="">
+   </image-compare>
 </body>
 </html>

--- a/src/js/compress.js
+++ b/src/js/compress.js
@@ -6,6 +6,9 @@ const ctx = canvas.getContext("2d");
 const downloadLink = document.getElementById("downloadLink");
 const imageCompare = document.querySelector('image-compare');
 
+/** @type {string} url - The object URL of the compressed image */
+let url
+
 /**
  * Loads an image on a slot in the <image-preview> component
  * @param {HTMLImageElement} img - The image to be loaded
@@ -17,6 +20,13 @@ function loadImage(img, slot, quality = 1) {
     quality = Number(quality); // Make sure quality is a number
   }
 
+  let imgEl = imageCompare.querySelector(`[slot="${slot}"]`);
+
+  if (quality === 1) {
+    imgEl.src = img.src; // Display the original image on the DOM
+    return;
+  }
+
   // Set canvas size to the image original size to ensure enough space for the image
   canvas.width = img.width;
   canvas.height = img.height;
@@ -25,15 +35,10 @@ function loadImage(img, slot, quality = 1) {
 
   canvas.toBlob(
     function (blob) {
-      let img = imageCompare.querySelector(`[slot="${slot}"]`);
-      let url = URL.createObjectURL(blob);
-
-      if (quality !== 1) {
-        downloadLink.href = url; // Display the download link for the compressed image
-      }
-
-      img.onload = () => URL.revokeObjectURL(url);
-      img.src = url;
+      URL.revokeObjectURL(url);        // Clear existing object URL from memory
+      url = URL.createObjectURL(blob); // Save the object URL of the new compressed image
+      imgEl.src = url;                 // Display the compressed image on the DOM
+      downloadLink.href = url;         // Update the download link for the compressed image
     },
     "image/jpeg",
     quality

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,3 +1,4 @@
+import '@cloudfour/image-compare'
 import {onChangeSliderVal, onChangeInputVal} from "./slider.js"
 import {compressImage, imageAdded} from "./compress.js"
 


### PR DESCRIPTION
I replaced `<img id="imgPreview">` with an `<image-compare>` web component that has a slider for comparing the original and compressed versions of an image.

Here's how it looks (the quality is set to 0 to make the distinction between the original and compressed versions more obvious):

![](https://github.com/joshjavier/image-compressroar/assets/46987872/ec897571-e386-476c-bb2c-27ad1a156142)

This imports the [@cloudfour/image-compare](https://www.npmjs.com/package/@cloudfour/image-compare) npm package to the `main.js` bundle. [Full documentation here.](https://image-compare-component.netlify.app/)

---

For context, I also tried [another image compare component](https://image-compare-viewer.netlify.app/) but although it has more customization options, it is not accessible and has a [larger bundle size](https://bundlephobia.com/package/image-compare-viewer@1.6.2) (3.3 kB) than [image-compare](https://bundlephobia.com/package/@cloudfour/image-compare@1.0.5) (1.6 kB).